### PR TITLE
Add automated C++ lint, build, format and test stages

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,29 +35,7 @@ AlignConsecutiveShortCaseStatements:
   Enabled:         false
   AcrossEmptyLines: false
   AcrossComments:  false
-  AlignCaseArrows: false
   AlignCaseColons: false
-AlignConsecutiveTableGenBreakingDAGArgColons:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  AlignFunctionPointers: false
-  PadOperators:    false
-AlignConsecutiveTableGenCondOperatorColons:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  AlignFunctionPointers: false
-  PadOperators:    false
-AlignConsecutiveTableGenDefinitionColons:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  AlignFunctionPointers: false
-  PadOperators:    false
 AlignEscapedNewlines: Left
 AlignOperands:   Align
 AlignTrailingComments:
@@ -67,7 +45,6 @@ AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowBreakBeforeNoexceptSpecifier: Never
 AllowShortBlocksOnASingleLine: Never
-AllowShortCaseExpressionOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: true
@@ -76,7 +53,9 @@ AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
 AttributeMacros:
   - __capability
 BinPackArguments: true
@@ -104,7 +83,6 @@ BraceWrapping:
 BreakAdjacentStringLiterals: true
 BreakAfterAttributes: Leave
 BreakAfterJavaFieldAnnotations: false
-BreakAfterReturnType: None
 BreakArrays:     true
 BreakBeforeBinaryOperators: None
 BreakBeforeConceptDeclarations: Always
@@ -112,10 +90,8 @@ BreakBeforeBraces: Attach
 BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
-BreakFunctionDefinitionParameters: false
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
-BreakTemplateDeclarations: Yes
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
@@ -175,15 +151,12 @@ IntegerLiteralSeparator:
   HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLines:
-  AtEndOfFile:     false
-  AtStartOfBlock:  false
-  AtStartOfFile:   true
+KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: false
 LambdaBodyIndentation: Signature
 LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
-MainIncludeChar: Quote
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Never
@@ -282,7 +255,6 @@ SpacesInLineCommentPrefix:
   Maximum:         -1
 SpacesInParens:  Never
 SpacesInParensOptions:
-  ExceptDoubleParentheses: false
   InCStyleCasts:   false
   InConditionalStatements: false
   InEmptyParentheses: false
@@ -294,7 +266,6 @@ StatementAttributeLikeMacros:
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
-TableGenBreakInsideDAGArg: DontBreak
 TabWidth:        8
 UseTab:          Never
 VerilogBreakBetweenInstancePorts: true
@@ -305,4 +276,3 @@ WhitespaceSensitiveMacros:
   - PP_STRINGIZE
   - STRINGIZE
 ...
-

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -10,12 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: clang-format
-      uses: jayllyz/clang-format-action@v1
-      with:
-        check: true
-        style: file
-        extensions: cxx,hpp
+    - name: Install clang-format
+      run: sudo apt-get install -y clang-format
+    - name: Debug
+      run: |
+        ls
+        pwd
+        ls *
+    - name: Clang-format
+      run: find . -name '*.cxx' -or -name '*.hpp' | xargs clang-format --dry-run -Werror
     
   build:
     runs-on: ubuntu-latest
@@ -41,6 +44,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Debug
+        run: |
+          ls
+          pwd
+          ls *
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Generate
-      run: cmake -S . -B bin -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      run: cmake -G Ninja -S . -B bin
     - name: Build
       run: |
           cd bin
-          make -j $(nproc)
+          ninja
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -39,11 +39,6 @@ jobs:
       with:
         name: build-output
         path: bin
-    - name: Debug
-      run: |
-        ls
-        pwd
-        ls *
     - name: Clang-tidy
       run: |
         find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy --use-color --header-filter=.* -p bin

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: C++ CI
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build
       run: |
           cd bin
-          ninja
+          make -j $(nproc)
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -33,19 +33,20 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    #- uses: actions/checkout@v4
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:
         name: build-output
     - name: Clang-tidy
       run: |
-        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy --use-color --header-filter=.* -p bin
+        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy --use-color --header-filter=.* -p .
 
   test:
     needs: build
     runs-on: ubuntu-24.04
     steps:
+      #- uses: actions/checkout@v4
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -57,4 +58,5 @@ jobs:
           ls *
       - name: Test
         run: |
+          chmod +x ./SafeCastTest
           ./SafeCastTest

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,18 @@
+name: GitHub Actions Demo
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -33,11 +33,16 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-    #- uses: actions/checkout@v4
+    - uses: actions/checkout@v4
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:
         name: build-output
+    - name: Debug
+      run: |
+        ls
+        pwd
+        ls *
     - name: Clang-tidy
       run: |
         find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy --use-color --header-filter=.* -p .

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -38,6 +38,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: build-output
+        path: bin
     - name: Debug
       run: |
         ls

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -16,34 +16,24 @@ jobs:
         check: true
         style: file
         extensions: cxx,hpp
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install clang-tidy
-      run: sudo apt-get install -y clang-tidy
-    - name: Run clang-tidy
-      run: |
-        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy -p build
-    - name: Echo
-      run: |
-        echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-        echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-        echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
     
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install clang-tidy
+      run: sudo apt-get install -y clang-tidy
     - name: Generate
-      run: cmake -S . -B bin
+      run: cmake -S . -B bin -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Build
       run: |
           cd bin
           make -j $(nproc)
+    - name: Clang-tidy
+      run: |
+        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy -p bin
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: build-output
         path: bin
@@ -51,9 +41,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      #- uses: actions/checkout@v2
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build-output
       - name: Test

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,18 +1,62 @@
-name: GitHub Actions Demo
-run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
-on: [push]
+name: C/C++ CI
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
 jobs:
-  Explore-GitHub-Actions:
+  format:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v4
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
+    - uses: actions/checkout@v4
+    - name: clang-format
+      uses: jayllyz/clang-format-action@v1
+      with:
+        check: true
+        style: file
+        extensions: cxx,hpp
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install clang-tidy
+      run: sudo apt-get install -y clang-tidy
+    - name: Run clang-tidy
+      run: |
+        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy -p build
+    - name: Echo
+      run: |
+        echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+        echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+        echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+    
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Generate
+      run: cmake -S . -B bin
+    - name: Build
+      run: |
+          cd bin
+          make -j $(nproc)
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-output
+        path: bin
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      #- uses: actions/checkout@v2
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+      - name: Test
         run: |
-          ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
+          cd bin
+          ./SafeCastTest

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -46,7 +46,7 @@ jobs:
         ls *
     - name: Clang-tidy
       run: |
-        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy --use-color --header-filter=.* -p .
+        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy --use-color --header-filter=.* -p bin
 
   test:
     needs: build

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -7,26 +7,16 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    #- name: Install clang-format
-      #run: sudo apt-get install -y clang-format
-    - name: Debug
-      run: |
-        clang-format --version
-        clang-tidy --version
-        pwd
-        clang-format -style=google -dump-config
     - name: Clang-format
       run: find . -name '*.cxx' -or -name '*.hpp' | xargs clang-format --dry-run -Werror
     
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
-    - name: Install clang-tidy
-      run: sudo apt-get install -y clang-tidy
     - name: Generate
       run: cmake -S . -B bin -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Build
@@ -41,9 +31,22 @@ jobs:
       with:
         name: build-output
         path: bin
+
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build-output
+    - name: Clang-tidy
+      run: |
+        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy --use-color --header-filter=.* -p bin
+
   test:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -56,5 +59,4 @@ jobs:
           ls *
       - name: Test
         run: |
-          cd bin
           ./SafeCastTest

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -23,9 +23,6 @@ jobs:
       run: |
           cd bin
           make -j $(nproc)
-    - name: Clang-tidy
-      run: |
-        find . -name '*.cxx' -or -name '*.hpp' | xargs clang-tidy -p bin
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -33,6 +30,7 @@ jobs:
         path: bin
 
   lint:
+    needs: build
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Generate
-      run: cmake -G Ninja -S . -B bin
+      run: cmake -S . -B bin
     - name: Build
       run: |
           cd bin
@@ -52,11 +52,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-output
-      - name: Debug
-        run: |
-          ls
-          pwd
-          ls *
       - name: Test
         run: |
           chmod +x ./SafeCastTest

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install clang-format
-      run: sudo apt-get install -y clang-format
+    #- name: Install clang-format
+      #run: sudo apt-get install -y clang-format
     - name: Debug
       run: |
-        ls
+        clang-format --version
+        clang-tidy --version
         pwd
-        ls *
     - name: Clang-format
       run: find . -name '*.cxx' -or -name '*.hpp' | xargs clang-format --dry-run -Werror
     

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -17,6 +17,7 @@ jobs:
         clang-format --version
         clang-tidy --version
         pwd
+        clang-format -style=google -dump-config
     - name: Clang-format
       run: find . -name '*.cxx' -or -name '*.hpp' | xargs clang-format --dry-run -Werror
     
@@ -44,15 +45,15 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
       - name: Debug
         run: |
           ls
           pwd
           ls *
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output
       - name: Test
         run: |
           cd bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ set_property(TARGET SafeCastTest PROPERTY CXX_STANDARD 20)
 target_link_libraries(SafeCastTest PRIVATE SafeCast GTest::gtest_main)
 gtest_discover_tests(SafeCastTest)
 
+set_target_properties(SafeCastTest PROPERTIES EXPORT_COMPILE_COMMANDS ON) # For clang-tidy
+
 # Up warning levels, many recommendations taken from:
 # https://github.com/cpp-best-practices/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
 if(MSVC)

--- a/src/safe_cast.hpp
+++ b/src/safe_cast.hpp
@@ -131,4 +131,3 @@ To safe_cast(From value) noexcept(false) {
 }  // namespace sc
 
 #endif  // _SAFE_CAST_HPP_
-


### PR DESCRIPTION
# Add C++ CI Workflow

This PR introduces a new GitHub Actions workflow for C++ continuous integration. The workflow includes steps for code formatting, building, linting, and testing.

## Changes

- Added a new file `.github/workflows/cpp-ci.yml` with the following jobs:
  - `format`: Checks code formatting using clang-format
  - `build`: Generates and builds the project using CMake and Ninja
  - `lint`: Runs clang-tidy for static code analysis
  - `test`: Executes the SafeCastTest

## Workflow Details

### Triggers
- On push to the `main` branch
- On pull requests targeting the `main` branch

### Jobs

#### Format
- Uses clang-format to check C++ files (*.cxx, *.hpp)
- Fails if any formatting issues are found

#### Build
- Generates the project using CMake
- Builds the project using Ninja
- Uploads build artifacts for use in subsequent jobs

#### Lint
- Depends on the successful completion of the build job
- Downloads build artifacts
- Runs clang-tidy on C++ files

#### Test
- Depends on the successful completion of the build job
- Downloads build artifacts
- Executes the SafeCastTest

## Benefits

- Ensures consistent code formatting across the project
- Catches build errors early
- Identifies potential issues through static code analysis
- Verifies the functionality of the code through automated tests

## Notes

- The workflow uses Ubuntu 24.04 as the runner OS
